### PR TITLE
Split export ZIP by content type within each modality

### DIFF
--- a/maxillo/utils/export_processor.py
+++ b/maxillo/utils/export_processor.py
@@ -136,6 +136,14 @@ class ExportProcessor:
         return False
 
     @staticmethod
+    def _content_bucket(file_type):
+        """Map a file_type to its ZIP content-type subfolder (raw vs processed)."""
+        file_type = file_type or ""
+        if file_type.endswith("_raw") or file_type.startswith("ios_raw_"):
+            return "raw"
+        return "processed"
+
+    @staticmethod
     def _infer_modality_slug_from_path(file_path):
         path = (file_path or "").lower()
         if "/raw/ios/" in path or "/processed/ios/" in path:
@@ -615,8 +623,10 @@ class ExportProcessor:
                                 or "file"
                             )
 
-                        # Create destination path: patient_folder/modality/filename
-                        dest_path = f"{patient_folder}/{modality_slug}/{filename}"
+                        # Create destination path:
+                        # patient_folder/modality/<raw|processed>/filename
+                        bucket = self._content_bucket(file_reg.file_type)
+                        dest_path = f"{patient_folder}/{modality_slug}/{bucket}/{filename}"
 
                         try:
                             with zipf.open(dest_path, mode="w", force_zip64=True) as zf:
@@ -632,15 +642,14 @@ class ExportProcessor:
                                 pct,
                             )
 
-                # Add report files: one folder per modality (reports_{slug}/)
+                # Add report files: patient_folder/modality/reports/
                 for modality_slug, reports in patient_data["reports"].items():
-                    report_folder = f"reports_{modality_slug}"
                     for report_info in reports:
                         content = report_info["content"]
                         user_id = report_info.get("user_id", "unknown")
                         vc_id = report_info["voice_caption"].id
                         filename = f"{user_id}_{vc_id}.txt"
-                        dest_path = f"{patient_folder}/{report_folder}/{filename}"
+                        dest_path = f"{patient_folder}/{modality_slug}/reports/{filename}"
                         zipf.writestr(dest_path, content)
                         current_entry[0] += 1
                         if total_entries and current_entry[0] % progress_interval == 0:

--- a/templates/maxillo/export_new.html
+++ b/templates/maxillo/export_new.html
@@ -105,7 +105,7 @@
                                     <i class="fas fa-file-alt me-1"></i>
                                     Reports
                                 </label>
-                                <small class="text-muted d-block ms-4 mt-1">Voice caption reports for each selected modality, saved in separate <code>reports_&lt;modality&gt;</code> folders.</small>
+                                <small class="text-muted d-block ms-4 mt-1">Voice caption reports for each selected modality, saved in <code>&lt;modality&gt;/reports/</code> folders.</small>
                             </div>
                             <small class="text-muted d-block">Select at least one content type.</small>
                         </div>


### PR DESCRIPTION
Previously raw and processed files for a modality were written into the same patient/<modality>/ folder, mixing content types (and risking filename collisions). Reports lived in a separate reports_<modality>/ folder.

Now each file is placed under patient/<modality>/<raw|processed>/ based on its file_type, and reports under patient/<modality>/reports/. Adds a _content_bucket() classifier on the shared ExportProcessor, so the new layout applies to both maxillo and brain. Laparoscopy uses its own processor and is unaffected.

Risolto il bug riportato da Matteo: prima un file zippato conteneva tanti file nella stessa directory che si sovrapponevano nei nomi e/o in ordine disordinato. 