### PR TITLE
fix(brain): let project viewers read captions they did not record

### DIFF
--- a/brain/tests_permissions.py
+++ b/brain/tests_permissions.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
 from brain.models import Folder, Patient, VoiceCaption
 from common.models import Project, ProjectAccess
@@ -65,3 +66,23 @@ class BrainProjectAclTests(TestCase):
         self.assertTrue(user_can_view_caption_content(viewer, caption, self.project))
         self.assertTrue(user_can_view_caption_content(pm, caption, self.project))
         self.assertFalse(user_can_view_caption_content(annotator, caption, self.project))
+
+    def test_brain_patient_detail_shows_caption_content_to_project_viewers(self):
+        """A viewer sees another user's caption content on the detail page.
+
+        The view used to inline "project admin or author", so every caption was
+        ghosted for the project's own viewers -- the public-demo guest included
+        -- while ``user_can_view_caption_content`` said otherwise.
+        """
+        owner = User.objects.create_user(username="brain_view_owner", password="x")
+        ProjectAccess.objects.create(user=owner, project=self.project, role="annotator")
+        VoiceCaption.objects.create(patient=self.patient, user=owner, duration=1.0)
+
+        self.client.force_login(self.viewer)
+        response = self.client.get(
+            reverse("brain:patient_detail", args=[self.patient.patient_id])
+        )
+        self.assertEqual(response.status_code, 200)
+        rendered = response.context["voice_captions"]
+        self.assertTrue(all(c.can_view_content for c in rendered))
+        self.assertFalse(any(c.can_edit_content for c in rendered))

--- a/brain/views.py
+++ b/brain/views.py
@@ -35,6 +35,7 @@ from common.permissions import (
     filter_patients_for_user,
     user_can_delete_single_patient,
     user_can_edit_caption,
+    user_can_view_caption_content,
     user_can_write_patient_annotations,
     project_allows_annotation,
     user_has_project_access,
@@ -162,11 +163,15 @@ def patient_detail(request, patient_id):
         else:
             patient_files["other"].append(file_data)
 
+    # Viewers and admins see all captions; annotators see only their own (to
+    # avoid bias during annotation). Through the canonical helpers -- this used
+    # to inline "admin or author", which ghosted every caption for the
+    # project's own viewers, the public-demo guest among them.
     voice_captions = patient.voice_captions.all()
     is_admin_user = user_is_project_admin(request.user, patient.project)
     for caption in voice_captions:
-        caption.can_view_content = bool(is_admin_user or caption.user_id == request.user.id)
-        caption.can_edit_content = bool(is_admin_user or caption.user_id == request.user.id)
+        caption.can_view_content = user_can_view_caption_content(request.user, caption)
+        caption.can_edit_content = user_can_edit_caption(request.user, caption)
         caption.is_ghost = not caption.can_view_content
 
     allowed_modalities = list(Modality.objects.filter(projects__id=request.session.get("current_project_id"), is_active=True))


### PR DESCRIPTION
## The bug

On `/brain/patient/<id>/`, a user with `viewer` access saw **"Caption content hidden"** for every voice caption they had not recorded themselves. Reported against the public-demo guest on `/brain/patient/783/`, but it affected every viewer on every brain project.

It is not a missing grant in the admin — no `ProjectAccess` role would have fixed it short of making the guest a project admin.

## Cause

`brain/views.py` inlined its own rule instead of calling the canonical helper:

```python
caption.can_view_content = bool(is_admin_user or caption.user_id == request.user.id)
```

`common/permissions.py::user_can_view_caption_content` states the actual policy:

| role | sees |
|---|---|
| author | own captions |
| viewer | **everything in the project** |
| admin | everything in the project |
| annotator | own only — deliberate bias guard during annotation |

`maxillo/views/patient_detail.py` already routes through the helper. Brain now does too, and uses `user_can_edit_caption` for the edit/delete controls (same semantics as the expression it replaces, but stated once rather than twice).

Worth noting: the gate on the audio bytes (`common/file_access.py:143`) already used the helper, so a viewer was always *authorized* to stream the file — the template just never rendered the play button for them. The divergence was confined to the view.

## Test

`brain/tests_permissions.py` asserted the helper directly, which is exactly why this stayed green. The new test drives the view: a viewer gets `can_view_content` on another user's caption, and still no `can_edit_content`.

```
brain.tests_permissions + maxillo.tests_permissions — 22 tests, OK (MySQL)
```

No migration, no template change, no admin change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)