### PR TITLE
feat(ui): tell phone visitors the site is built for a desktop

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -6,6 +6,7 @@
  * ygg-ui.css. This file keeps only:
  *   1. @font-face for the self-hosted IBM Plex families (GDPR: no CDN fonts).
  *   2. The fixed footer + 64px icon-rail app-shell layout.
+ *   3. The desktop-only gate shown at phone widths.
  * It MUST NOT restyle annotation viewers — viewer pages inherit this file.
  *
  * Bootstrap is gone as of the 2.0 rebuild; the chromatic overrides and the
@@ -147,4 +148,71 @@ body.has-rail .ygg-footer { left: var(--ygg-rail-w); }
     body.has-rail .ygg-rail { transform: translateX(-100%); transition: transform .2s; }
     body.has-rail.rail-open .ygg-rail { transform: none; }
     body.has-rail .ygg-footer { left: 0; }
+}
+
+/* ==========================================================================
+ * Desktop-only gate — the honest counterpart to the rule above.
+ *
+ * Below phone width the rail is translated off-canvas and nothing reopens it,
+ * and the viewers were never laid out for a 390px column. Rather than serve a
+ * silently broken page, base.html carries an interstitial that is invisible at
+ * desktop widths and paints over everything here. No JS and no User-Agent
+ * sniffing: the media query IS the detection. Colours are all --ygg-* tokens,
+ * so it follows the data-theme stamp with no dark-mode rules of its own.
+ *
+ * The landscape clause catches a rotated phone (~850px wide, so a bare
+ * max-width would let it through); max-height keeps laptops out.
+ * ======================================================================== */
+.ygg-desktop-gate { display: none; }
+
+@media (max-width: 640px), (orientation: landscape) and (max-height: 480px) {
+    html, body { overflow: hidden; }
+    .ygg-desktop-gate {
+        display: flex;
+        position: fixed;
+        inset: 0;
+        /* Above the maintenance banner (2100), toasts (2000) and modals (1050). */
+        z-index: 3000;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        background: var(--ygg-surface-alt);
+    }
+    .ygg-desktop-gate__card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
+        max-width: 22rem;
+        padding: 2rem 1.5rem 1.75rem;
+        border: 1px solid var(--ygg-border);
+        border-radius: var(--ygg-radius-lg);
+        background: var(--ygg-surface);
+        box-shadow: var(--ygg-shadow-card-light);
+        text-align: center;
+    }
+    .ygg-desktop-gate__logo {
+        width: 4.5rem;
+        height: auto;
+        animation: ygg-gate-float 3.2s ease-in-out infinite;
+    }
+    .ygg-desktop-gate__title {
+        margin-top: 0.5rem;
+        font-size: 1.125rem;
+        line-height: 1.4;
+    }
+    .ygg-desktop-gate__text {
+        margin: 0;
+        color: var(--ygg-text-muted);
+        font-size: 0.875rem;
+        line-height: 1.55;
+    }
+}
+
+@keyframes ygg-gate-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-6px); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .ygg-desktop-gate__logo { animation: none; }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,6 +81,26 @@
        The old ygg-nav top bar was removed with the 3.0 release. {% endcomment %}
     {% block chrome %}{% endblock %}{# chrome #}
 
+    {% comment %} Desktop-only gate. Yggdrasil's working pages are Cornerstone3D
+       viewers and dense tables; below phone width the icon rail is off-canvas
+       with no way back, so instead of a silently broken page we paint an honest
+       interstitial. Pure CSS (theme.css) -- shown/hidden by media query alone,
+       and deliberately free of context variables so 500.html, which renders
+       without context processors, still gets it. {% endcomment %}
+    {% block mobile_gate %}
+    <div class="ygg-desktop-gate" role="alertdialog" aria-labelledby="ygg-gate-title">
+        <div class="ygg-desktop-gate__card">
+            <img class="ygg-desktop-gate__logo" src="{% static 'icons/logo-yggdrasil.png' %}" alt="">
+            {% include 'common/partials/wordmark.html' with variant='ink' size='lg' %}
+            <h1 id="ygg-gate-title" class="ygg-desktop-gate__title">Best viewed on a bigger screen</h1>
+            <p class="ygg-desktop-gate__text">
+                Yggdrasil's imaging viewers need room to grow &mdash; open it on a
+                laptop or desktop and the tree will be waiting. &#127794;
+            </p>
+        </div>
+    </div>
+    {% endblock %}{# mobile_gate #}
+
     {% block messages %}
     {% if messages %}
         <script>


### PR DESCRIPTION
Phone visitors currently get a page that is broken without saying so: `theme.css` slides the icon rail off-canvas below 640px and nothing ever sets `.rail-open` (`nav.js` has no rail handler, and no `[data-mobile-toggle]` markup exists), so the primary navigation is simply unreachable. On top of that the viewers were never laid out for a 390px column.

This paints an honest interstitial instead — tree logo, wordmark, and a line pointing at a bigger screen.

## How it works

- **`templates/base.html`** — a `{% block mobile_gate %}` after `{% block chrome %}`, so it covers every page: login, landing, viewers, error templates. It uses only `{% static %}` and the existing `common/partials/wordmark.html` include, no context variables, so `500.html` (rendered with context processors disabled, per the note in `error_base.html`) still gets it.
- **`static/css/theme.css`** — `display: none` by default; paints only inside `@media (max-width: 640px), (orientation: landscape) and (max-height: 480px)`. Detection is the media query itself: no JS, no User-Agent sniffing. The width breakpoint is the same 640px the file already uses for the rail; the landscape clause catches a rotated phone (~850px wide) that a bare `max-width` would let through, and `max-height` keeps laptops out.

Every colour is a `--ygg-*` token, so light/dark follows the existing `data-theme` stamp with no dark-mode rules of its own. The logo has a slow float that `prefers-reduced-motion` disables.

## Decisions worth a reviewer's eye

- **Hard block, no escape hatch** — including on pages that would work fine on a phone (login, maintenance, 404). The `mobile_gate` block is the opt-out if we later want one of those usable.
- **CSS-only, so the page behind stays in the DOM** under an opaque layer rather than being removed from the accessibility tree. `role="alertdialog"` plus the heading means assistive tech lands on the explanation first — judged a fair trade for zero JS.

## Verification

- Full suite against MySQL: `Ran 1314 tests in 248s, OK`.
- Nothing under `frontend/` or `tailwind.src.css` is touched — plain hand-written CSS only — so no `npm run build` / `build_css.sh` and no bundle diff for CI to catch.
- Not yet opened in a real browser; worth a look in the DevTools device toolbar (portrait *and* landscape, both themes) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)