### PR TITLE
fix: unbreak job reruns (SLURM input keys, CSRF 403) and add a step picker to the patient header

### DIFF
--- a/brain/views.py
+++ b/brain/views.py
@@ -227,6 +227,8 @@ def patient_detail(request, patient_id):
             m["slug"] for m in patient_modalities
             if m.get("slug") not in ("rawzip", "braintumor-mri-seg")
         ],
+        # Checkbox labels for the shared rerun picker (common/partials/rerun_modal.html).
+        "rerun_step_labels": rerun_step_labels(patient_files, patient_modalities),
         "allowed_modalities": allowed_modalities,
         "allowed_modality_slugs": [m.slug for m in allowed_modalities],
         # report_language now provided globally by common.context_processors.user_prefs

--- a/common/runner/run.py
+++ b/common/runner/run.py
@@ -33,12 +33,27 @@ _STORAGE_KEYS = (
 
 
 def iter_input_keys(input_files):
-    """Yield every object-storage key (string leaf) in the input_files structure."""
+    """Yield every object-storage key in the input_files structure.
+
+    A string leaf *is* a key, with one exception: the legacy file-descriptor dict
+    ``{"path": ..., "filename": ..., "content_type": ...}``. Jobs completed before
+    2026-07-29 stored ``output_files`` in that shape, and
+    :meth:`common.models.Job._pull_dependency_outputs` merges a dependency's
+    ``output_files`` into its dependents' ``input_files`` verbatim -- so those dicts
+    still reach the runner today. Walking one leaf-by-leaf would hand the cluster
+    ``lower_oriented.stl`` and ``model/stl`` as keys alongside the real path, and
+    ``ygg-stage pull`` fails the whole job on the first 404. Only ``path`` is a key.
+    """
     def walk(obj):
         if isinstance(obj, str):
             if obj:
                 yield obj
         elif isinstance(obj, dict):
+            path = obj.get("path")
+            if isinstance(path, str):
+                if path:
+                    yield path
+                return
             for v in obj.values():
                 yield from walk(v)
         elif isinstance(obj, (list, tuple)):

--- a/common/tests_runner.py
+++ b/common/tests_runner.py
@@ -206,6 +206,35 @@ class RunHelperTests(SimpleTestCase):
         self.assertEqual(set(keys), {"p/u.stl", "p/l.stl", "p/f.stl"})
         self.assertEqual(len(keys), 3)  # de-duplicated
 
+    def test_iter_input_keys_legacy_descriptor_yields_only_path(self):
+        # Shape of a pre-2026-07-29 `ios` job's output_files, merged in as this job's
+        # input by Job._pull_dependency_outputs. `filename`/`content_type` are not keys.
+        keys = list(run_mod.iter_input_keys({
+            "ios": {
+                "lower": {
+                    "path": "maxillo/processed/ios/job_20269/lower_oriented.stl",
+                    "filename": "lower_oriented.stl",
+                    "content_type": "model/stl",
+                },
+                "upper": {
+                    "path": "maxillo/processed/ios/job_20269/upper_oriented.stl",
+                    "filename": "upper_oriented.stl",
+                    "content_type": "model/stl",
+                },
+            }
+        }))
+        self.assertEqual(keys, [
+            "maxillo/processed/ios/job_20269/lower_oriented.stl",
+            "maxillo/processed/ios/job_20269/upper_oriented.stl",
+        ])
+
+    def test_iter_input_keys_mixes_descriptor_and_plain_dependencies(self):
+        keys = list(run_mod.iter_input_keys({
+            "ios": {"upper": {"path": "p/u.stl", "filename": "u.stl", "content_type": "model/stl"}},
+            "cbct": {"segmentation_nifti": "p/seg.nii.gz"},
+        }))
+        self.assertEqual(set(keys), {"p/u.stl", "p/seg.nii.gz"})
+
     def test_render_creds_env_has_storage_and_io(self):
         body = run_mod.render_creds_env(["p/a.stl", "p/b.stl"], "proj/processed/ios/job_5")
         self.assertIn("export OBJECT_STORAGE_ENDPOINT_URL=", body)

--- a/maxillo/tests_rerun_steps.py
+++ b/maxillo/tests_rerun_steps.py
@@ -97,6 +97,48 @@ class RerunButtonStepsTests(MaxilloRerunStepsBase):
         self.assertNotContains(response, "human label map consumed")
 
 
+class RerunHeaderPickerTests(MaxilloRerunStepsBase):
+    """The detail-page Rerun button opens the same step picker as the list page."""
+
+    def _detail(self, patient):
+        return self.client.get(
+            reverse("maxillo:patient_detail", args=[patient.patient_id])
+        )
+
+    def test_detail_page_renders_picker_with_step_slugs_and_labels(self):
+        patient = self._ios_patient()
+
+        response = self._detail(patient)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="headerRerunBtn"')
+        self.assertContains(response, 'id="rerunProcessingModal"')
+        self.assertContains(response, 'id="confirmRerunBtn"')
+        self.assertContains(response, '"ios": "IOS Orientation"')
+        self.assertContains(response, '"ios-bite-classification": "IOS Bite Classification"')
+        content = response.content.decode()
+        self.assertIn('"ios","ios-landmarks","ios-bite-classification"', content)
+        # The picker replaced the old "rerun everything" confirm().
+        self.assertNotIn("Rerun processing for all modalities", content)
+
+    def test_pages_render_a_csrf_token_and_no_cookie_scraping(self):
+        # CSRF_USE_SESSIONS + CSRF_COOKIE_HTTPONLY: document.cookie carries no usable
+        # token, so a scripted POST that scrapes it sends the wrong value and Django
+        # answers 403 "CSRF token ... has incorrect length". base.html renders the tag.
+        patient = self._ios_patient()
+
+        for response in (self._detail(patient), self.client.get(reverse("maxillo:patient_list"))):
+            self.assertContains(response, 'name="csrfmiddlewaretoken"')
+            self.assertNotIn("document.cookie.match(/csrftoken=", response.content.decode())
+
+    def test_detail_page_without_steps_hides_the_button_and_modal(self):
+        patient = Patient.objects.create(name="Plain", project=self.project, folder=self.folder)
+
+        response = self._detail(patient)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="headerRerunBtn"')
+        self.assertNotContains(response, 'id="rerunProcessingModal"')
+
+
 @patch("common.signals.celery_app.send_task")
 class RerunProcessingCreatesJobsTests(MaxilloRerunStepsBase):
     def test_rerun_creates_missing_step_jobs_for_existing_patient(self, _send_task):

--- a/maxillo/views/patient_detail.py
+++ b/maxillo/views/patient_detail.py
@@ -728,14 +728,17 @@ def patient_detail(request, patient_id):
 
     # Processing steps possible for this patient's rerun ("Rerun" header action).
     try:
-        from common.modality_config import rerunnable_steps_for_patient
+        from common.modality_config import rerun_step_labels, rerunnable_steps_for_patient
         _rerunnable = rerunnable_steps_for_patient(patient_file_rows, [], patient=patient)
         rerunnable_step_slugs = [step['slug'] for step in _rerunnable]
+        # Checkbox labels for the shared rerun picker (common/partials/rerun_modal.html).
+        rerun_step_labels_map = rerun_step_labels(patient_file_rows, patient_modalities)
     except Exception:
         logger.warning("Failed to compute rerunnable steps for patient %s", patient.patient_id, exc_info=True)
         rerunnable_step_slugs = [
             m.get('slug') for m in patient_modalities if m.get('slug') != 'rawzip'
         ]
+        rerun_step_labels_map = {}
 
     # Raw inputs freeze once annotation work exists; the panoramic freezes on
     # everything except its own state (see common.annotation_lock).
@@ -770,6 +773,7 @@ def patient_detail(request, patient_id):
         'can_create_caption': can_create_caption,
         'modality_files': modality_files,
         'rerunnable_step_slugs': rerunnable_step_slugs,
+        'rerun_step_labels': rerun_step_labels_map,
         'viewer_grid_data': viewer_grid_data,
     }
     # Allowed modalities for current project (to conditionally show upload controls)

--- a/static/css/patient_list.css
+++ b/static/css/patient_list.css
@@ -479,18 +479,6 @@
 .folder-menu__item--danger { color: var(--ygg-danger); }
 .folder-menu__item--danger:hover { background: var(--ygg-danger-soft); }
 
-/* ---- Modal bits shared with the rerun dialogs -------------------------- */
-.modal-sub { margin: 0 0 10px; font-size: 12px; color: var(--ygg-text-muted); }
-.modal-note { margin: 10px 0 0; font-size: 12px; color: var(--ygg-text-muted); }
-.check-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 5px 0;
-    font-size: 13px;
-}
-.check-row label { cursor: pointer; }
-
 .perm-form {
     display: grid;
     grid-template-columns: 2fr 1.5fr auto;

--- a/static/css/ygg-ui.css
+++ b/static/css/ygg-ui.css
@@ -262,3 +262,16 @@ body.ygg-modal-open { overflow: hidden; }
 @media (prefers-reduced-motion: reduce) {
     .ygg-toast { animation: none; }
 }
+
+/* ---- Rerun / confirm dialog bits (shared: patients list + patient header) --- */
+.modal-sub { margin: 0 0 10px; font-size: 12px; color: var(--ygg-text-muted); }
+.modal-note { margin: 10px 0 0; font-size: 12px; color: var(--ygg-text-muted); }
+.check-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 0;
+    font-size: 13px;
+}
+.check-row label { cursor: pointer; }
+

--- a/static/js/notifications_feed.js
+++ b/static/js/notifications_feed.js
@@ -17,10 +17,6 @@
     var empty = bell.querySelector('[data-notif-empty]');
     var markAll = bell.querySelector('[data-notif-mark-all]');
 
-    function csrf() {
-        var m = document.cookie.match(/csrftoken=([^;]+)/);
-        return m ? m[1] : '';
-    }
 
     var LEVEL_ICON = {
         success: 'fa-circle-check',
@@ -69,7 +65,7 @@
         if (!window.YGG_NOTIF_MARK) return;
         fetch(window.YGG_NOTIF_MARK, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf() },
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': window.yggCsrfToken() },
             body: JSON.stringify(id ? { id: id } : {}),
         }).then(function () { refresh(); }).catch(function () {});
     }

--- a/static/js/patient_list.js
+++ b/static/js/patient_list.js
@@ -267,133 +267,36 @@ function initAdminActions() {
         });
     });
     
-    // Rerun processing handler with modal selection
-    const rerunModalEl = document.getElementById('rerunProcessingModal');
-    let rerunModal = null;
-    let rerunTargetScanId = null;
-    let rerunSelectedSlugs = [];
-    const rerunModalityOptionsEl = document.getElementById('rerunModalityOptions');
-    const rerunLabelsEl = document.getElementById('rerun-modality-labels');
-    let rerunModalityLabels = {};
-    if (rerunLabelsEl) {
-        try {
-            rerunModalityLabels = JSON.parse(rerunLabelsEl.textContent || '{}');
-        } catch (_err) {
-            rerunModalityLabels = {};
-        }
-    }
-    window.rerunModalityLabels = rerunModalityLabels;
-
-    function renderRerunOptions(modalitySlugs) {
-        if (!rerunModalityOptionsEl) return;
-        rerunModalityOptionsEl.innerHTML = '';
-        if (!modalitySlugs.length) {
-            rerunModalityOptionsEl.innerHTML = '<p class="modal-note">No rerunnable processing steps available for this patient.</p>';
-            return;
-        }
-
-        modalitySlugs.forEach((slug, index) => {
-            const safeSlug = String(slug || '').trim();
-            if (!safeSlug) return;
-            const wrapper = document.createElement('div');
-            wrapper.className = 'check-row';
-            const checkboxId = `rerunModality_${safeSlug}_${index}`;
-            const label = rerunModalityLabels[safeSlug] || safeSlug.replace(/_/g, ' ');
-            wrapper.innerHTML = `
-                <input class="rerun-modality-checkbox" type="checkbox" value="${safeSlug}" id="${checkboxId}" data-modality-slug="${safeSlug}">
-                <label for="${checkboxId}">${label}</label>
-            `;
-            rerunModalityOptionsEl.appendChild(wrapper);
-        });
-    }
-
-    if (rerunModalEl && window.bootstrap) {
-        rerunModal = new window.bootstrap.Modal(rerunModalEl);
-    }
+    // Rerun processing: one row's button opens the shared picker
+    // (static/js/rerun_modal.js), which owns the modal and the POST.
     document.querySelectorAll('.btn-rerun-processing').forEach(btn => {
         btn.addEventListener('click', function(e) {
             e.preventDefault();
-            rerunTargetScanId = this.dataset.scanId;
-            const scanName = this.dataset.scanName || `Scan #${rerunTargetScanId}`;
-            const subtitle = document.getElementById('rerunScanSubtitle');
-            if (subtitle) subtitle.textContent = scanName;
-            rerunSelectedSlugs = (this.dataset.availableSteps || '')
-                .split(',')
-                .map(s => s.trim())
-                .filter(Boolean)
-                .filter((slug, idx, arr) => arr.indexOf(slug) === idx);
-            renderRerunOptions(rerunSelectedSlugs);
-            if (rerunModal) rerunModal.show();
-        });
-    });
-    const confirmRerunBtn = document.getElementById('confirmRerunBtn');
-    if (confirmRerunBtn) {
-        confirmRerunBtn.addEventListener('click', function() {
-            const jobs = Array.from(document.querySelectorAll('.rerun-modality-checkbox:checked')).map(el => el.value);
-            if (!jobs.length) {
-                showNotification('error', 'Select at least one job to rerun');
-                return;
-            }
-            const label = this.querySelector('.label');
-            const spinner = this.querySelector('.spinner');
-            this.disabled = true;
-            if (label) label.classList.add('hidden');
-            if (spinner) spinner.classList.remove('hidden');
-            secureFetch(`/${window.projectNamespace}/patient/${rerunTargetScanId}/rerun-processing/`, {
-                method: 'POST',
-                body: JSON.stringify({ jobs })
-            }).then(parseJsonResponse).then(data => {
-                if (data.success) {
-                    showNotification('success', data.message || 'Jobs set to pending');
-                    if (rerunModal) rerunModal.hide();
-                    // Update status indicators for this row based on selected jobs
-                    const row = document.querySelector(`.patient-row[data-scan-id="${rerunTargetScanId}"]`) || document.querySelector(`.scan-row[data-scan-id="${rerunTargetScanId}"]`);
-                    if (row) {
-                        jobs.forEach(slug => {
-                            const pill = row.querySelector(`.status-pill[data-modality-slug="${slug}"]`);
-                            if (!pill) return;
-                            pill.classList.remove('status-processed', 'status-failed', 'status-pending', 'status-absent');
-                            pill.classList.add('status-processing');
-                        });
-                    }
-                } else {
-                    showNotification('error', data.error || 'Failed to rerun jobs');
+            const scanId = this.dataset.scanId;
+            window.YggRerunModal.open({
+                patientId: scanId,
+                patientName: this.dataset.scanName || `Scan #${scanId}`,
+                steps: this.dataset.availableSteps,
+                onSuccess: (jobs) => {
+                    // Reflect the new state without a reload: the rerun rows are now queued.
+                    const row = document.querySelector(`.patient-row[data-scan-id="${scanId}"]`) || document.querySelector(`.scan-row[data-scan-id="${scanId}"]`);
+                    if (!row) return;
+                    jobs.forEach(slug => {
+                        const pill = row.querySelector(`.status-pill[data-modality-slug="${slug}"]`);
+                        if (!pill) return;
+                        pill.classList.remove('status-processed', 'status-failed', 'status-pending', 'status-absent');
+                        pill.classList.add('status-processing');
+                    });
                 }
-            }).catch(error => showNotification('error', error.message || 'Network error')).finally(() => {
-                confirmRerunBtn.disabled = false;
-                if (label) label.classList.remove('hidden');
-                if (spinner) spinner.classList.add('hidden');
             });
         });
-    }
-}
-
-// Utility function to get CSRF token with validation
-function getCookie(name) {
-    let cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-        const cookies = document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-            const cookie = cookies[i].trim();
-            if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
+    });
 }
 
 // SECURITY: Enhanced CSRF token validation
 function getCSRFToken() {
-    // When CSRF_USE_SESSIONS = True, token is in hidden form, not cookies
-    const csrfInput = document.querySelector('input[name="csrfmiddlewaretoken"]');
-    if (csrfInput) {
-        return csrfInput.value;
-    }
-    
-    // Fallback to cookie method for backwards compatibility
-    const token = getCookie('csrftoken');
+    // Single reader for the whole app; base.html renders the tag it reads.
+    const token = window.yggCsrfToken();
     if (!token) {
         console.error('SECURITY: CSRF token not found. This may indicate a security issue.');
         showNotification('error', 'Security token missing. Please refresh the page.');
@@ -613,7 +516,7 @@ function initBulkSelection() {
             const wrapper = document.createElement('div');
             wrapper.className = 'check-row';
             const checkboxId = `bulkRerunModality_${safeSlug}_${index}`;
-            const label = (window.rerunModalityLabels && window.rerunModalityLabels[safeSlug]) || safeSlug.replace(/_/g, ' ');
+            const label = window.YggRerunModal.labels()[safeSlug] || safeSlug.replace(/_/g, ' ');
             wrapper.innerHTML = `
                 <input class="bulk-rerun-modality-checkbox" type="checkbox" value="${safeSlug}" id="${checkboxId}" data-modality-slug="${safeSlug}">
                 <label for="${checkboxId}">${label}</label>

--- a/static/js/rerun_modal.js
+++ b/static/js/rerun_modal.js
@@ -1,0 +1,150 @@
+/*
+ * Single-patient rerun picker (#rerunProcessingModal, templates/common/partials/rerun_modal.html).
+ *
+ * Both entry points -- a row's rerun button on the patients list and the Rerun button in
+ * the patient-detail header -- post the same body to the same endpoint, and differ only in
+ * what they do afterwards. So the modal lives here once and each page passes its own
+ * `onSuccess`: the list flips that row's status pills, the detail page reloads.
+ */
+(function () {
+    'use strict';
+
+
+    function notify(type, message) {
+        if (window.appNotify) window.appNotify(type, message);
+    }
+
+    function labels() {
+        if (window.rerunModalityLabels) return window.rerunModalityLabels;
+        var el = document.getElementById('rerun-modality-labels');
+        var parsed = {};
+        if (el) {
+            try {
+                parsed = JSON.parse(el.textContent || '{}');
+            } catch (_err) {
+                parsed = {};
+            }
+        }
+        window.rerunModalityLabels = parsed;
+        return parsed;
+    }
+
+    function renderOptions(slugs) {
+        var container = document.getElementById('rerunModalityOptions');
+        if (!container) return;
+        container.innerHTML = '';
+        if (!slugs.length) {
+            container.innerHTML = '<p class="modal-note">No rerunnable processing steps available for this patient.</p>';
+            return;
+        }
+        var map = labels();
+        slugs.forEach(function (slug, index) {
+            var safeSlug = String(slug || '').trim();
+            if (!safeSlug) return;
+            var wrapper = document.createElement('div');
+            wrapper.className = 'check-row';
+            var checkboxId = 'rerunModality_' + safeSlug + '_' + index;
+            var label = map[safeSlug] || safeSlug.replace(/_/g, ' ');
+            wrapper.innerHTML =
+                '<input class="rerun-modality-checkbox" type="checkbox" value="' + safeSlug + '" id="' + checkboxId + '" data-modality-slug="' + safeSlug + '">' +
+                '<label for="' + checkboxId + '"></label>';
+            wrapper.querySelector('label').textContent = label;
+            container.appendChild(wrapper);
+        });
+    }
+
+    /** Normalize the several shapes callers hold slugs in: array, or a "a,b,c" data attribute. */
+    function normalizeSteps(steps) {
+        var list = Array.isArray(steps) ? steps : String(steps || '').split(',');
+        return list
+            .map(function (s) { return String(s || '').trim(); })
+            .filter(Boolean)
+            .filter(function (slug, idx, arr) { return arr.indexOf(slug) === idx; });
+    }
+
+    var state = { patientId: null, onSuccess: null };
+    var modal = null;
+    var wired = false;
+
+    function submit(button) {
+        var jobs = Array.prototype.slice
+            .call(document.querySelectorAll('.rerun-modality-checkbox:checked'))
+            .map(function (el) { return el.value; });
+        if (!jobs.length) {
+            notify('error', 'Select at least one job to rerun');
+            return;
+        }
+        var label = button.querySelector('.label');
+        var spinner = button.querySelector('.spinner');
+        button.disabled = true;
+        if (label) label.classList.add('hidden');
+        if (spinner) spinner.classList.remove('hidden');
+
+        var token = window.yggCsrfToken();
+        if (!token) {
+            notify('error', 'Security token missing. Please refresh the page.');
+            button.disabled = false;
+            if (label) label.classList.remove('hidden');
+            if (spinner) spinner.classList.add('hidden');
+            return;
+        }
+        fetch('/' + window.projectNamespace + '/patient/' + state.patientId + '/rerun-processing/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': token },
+            body: JSON.stringify({ jobs: jobs })
+        }).then(function (response) {
+            return response.json().catch(function () {
+                throw new Error('Server error (' + response.status + ')');
+            });
+        }).then(function (data) {
+            if (!data.success) {
+                notify('error', data.error || 'Failed to rerun jobs');
+                return;
+            }
+            notify('success', data.message || 'Jobs set to pending');
+            if (modal) modal.hide();
+            if (state.onSuccess) state.onSuccess(jobs, data);
+        }).catch(function (error) {
+            notify('error', error.message || 'Network error');
+        }).finally(function () {
+            button.disabled = false;
+            if (label) label.classList.remove('hidden');
+            if (spinner) spinner.classList.add('hidden');
+        });
+    }
+
+    function ensureWired() {
+        if (wired) return true;
+        var modalEl = document.getElementById('rerunProcessingModal');
+        if (!modalEl || !window.bootstrap) return false;
+        modal = new window.bootstrap.Modal(modalEl);
+        var confirmBtn = document.getElementById('confirmRerunBtn');
+        if (confirmBtn) {
+            confirmBtn.addEventListener('click', function () { submit(this); });
+        }
+        wired = true;
+        return true;
+    }
+
+    window.YggRerunModal = {
+        /** Slug -> display name, parsed once from #rerun-modality-labels. */
+        labels: labels,
+
+        /**
+         * @param {object} options
+         * @param {number|string} options.patientId  patient the rerun applies to
+         * @param {string}        [options.patientName]  shown as the modal subtitle
+         * @param {string[]|string} options.steps   rerunnable step slugs (array or "a,b,c")
+         * @param {function}      [options.onSuccess]  called with (jobs, data) after a rerun
+         */
+        open: function (options) {
+            if (!ensureWired()) return;
+            state.patientId = options.patientId;
+            state.onSuccess = options.onSuccess || null;
+            var subtitle = document.getElementById('rerunScanSubtitle');
+            if (subtitle) subtitle.textContent = options.patientName || ('Scan #' + options.patientId);
+            renderOptions(normalizeSteps(options.steps));
+            modal.show();
+        }
+    };
+})();

--- a/static/js/ygg-ui.js
+++ b/static/js/ygg-ui.js
@@ -281,6 +281,23 @@
         initTooltips(document);
     });
 
+    /* ---------------------------------------------------------------- csrf */
+
+    /**
+     * The page's CSRF token, for scripted POSTs.
+     *
+     * Settings turn on CSRF_USE_SESSIONS and CSRF_COOKIE_HTTPONLY, so the token lives
+     * in the session and the cookie is unreadable from JS. Call sites that scraped
+     * `document.cookie` sent whatever unrelated value the regex happened to match and
+     * Django rejected it with "CSRF token ... has incorrect length" -- a 403 that only
+     * showed up on the buttons nobody clicked in a test. base.html renders the tag on
+     * every page; this is the one place that reads it.
+     */
+    window.yggCsrfToken = function () {
+        var input = document.querySelector('input[name="csrfmiddlewaretoken"]');
+        return input ? input.value : '';
+    };
+
     /* ------------------------------------------------------------- exports */
 
     window.YggUI = {

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,6 +75,12 @@
     </div>
     {% endif %}
 
+    {% comment %} CSRF_USE_SESSIONS is on and CSRF_COOKIE_HTTPONLY hides the cookie, so
+       document.cookie carries no usable token: every scripted POST reads this tag via
+       window.yggCsrfToken() (static/js/ygg-ui.js). Rendered once, here, because the
+       fetches that need it live in partials that no single page owns. {% endcomment %}
+    <form style="display:none;" aria-hidden="true">{% csrf_token %}</form>
+
     {% comment %} base.html carries no nav of its own: authenticated working
        pages get the rail + breadcrumb topbar via common/base_app.html, while
        landing/auth/error pages either bring their own chrome or blank it.

--- a/templates/common/partials/patient_list_content.html
+++ b/templates/common/partials/patient_list_content.html
@@ -20,7 +20,6 @@
   be rendered once.
 {% endcomment %}
 <!-- Hidden CSRF token for AJAX usage -->
-<form style="display:none;">{% csrf_token %}</form>
 
 <div class="patients-page">
 
@@ -303,35 +302,7 @@ granularity the system has never had.{% endcomment %}
 </div>
 {% endif %}
 
-<div class="modal" id="rerunProcessingModal" tabindex="-1" aria-labelledby="rerunProcessingModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="rerunProcessingModalLabel">Rerun processing</h5>
-        <button type="button" class="btn-close" data-ygg-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <p class="modal-sub" id="rerunScanSubtitle"></p>
-        <div id="rerunModalityOptions"></div>
-        <p class="modal-note">Select the processing steps to re-run. Missing pipeline jobs are created automatically.</p>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="ygg-btn ygg-btn--ghost" data-ygg-dismiss="modal">Cancel</button>
-        <button type="button" class="ygg-btn ygg-btn--primary" id="confirmRerunBtn">
-          <span class="label">Rerun selected</span>
-          <span class="spinner hidden"><i class="fas fa-spinner fa-spin" aria-hidden="true"></i></span>
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-
-{% comment %} Slug -> human label map consumed by patient_list.js (window.rerunModalityLabels).
-Labels are ProcessingStep names (admin/common/processingstep), falling back to modality
-labels when a domain declares no processing steps. {% endcomment %}
-<script id="rerun-modality-labels" type="application/json">{
-{% for slug, label in rerun_step_labels.items %}"{{ slug }}": "{{ label }}"{% if not forloop.last %},{% endif %}{% endfor %}
-}</script>
+{% include 'common/partials/rerun_modal.html' %}
 
 <div class="modal" id="bulkRerunProcessingModal" tabindex="-1" aria-labelledby="bulkRerunProcessingModalLabel" aria-hidden="true">
   <div class="modal-dialog">

--- a/templates/common/partials/rerun_modal.html
+++ b/templates/common/partials/rerun_modal.html
@@ -1,0 +1,38 @@
+{% comment %}
+  Single-patient rerun picker. Shared by the patients list (one row's rerun button)
+  and the patient-detail header, both of which POST the ticked slugs to
+  `patient/<id>/rerun-processing/`. Driven by static/js/rerun_modal.js
+  (window.YggRerunModal); the including page supplies the available slugs per button.
+
+  The bulk variant (#bulkRerunProcessingModal) stays in patient_list_content.html --
+  it is list-only and takes a patient selection, not one patient.
+{% endcomment %}
+<div class="modal" id="rerunProcessingModal" tabindex="-1" aria-labelledby="rerunProcessingModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="rerunProcessingModalLabel">Rerun processing</h5>
+        <button type="button" class="btn-close" data-ygg-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="modal-sub" id="rerunScanSubtitle"></p>
+        <div id="rerunModalityOptions"></div>
+        <p class="modal-note">Select the processing steps to re-run. Missing pipeline jobs are created automatically.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="ygg-btn ygg-btn--ghost" data-ygg-dismiss="modal">Cancel</button>
+        <button type="button" class="ygg-btn ygg-btn--primary" id="confirmRerunBtn">
+          <span class="label">Rerun selected</span>
+          <span class="spinner hidden"><i class="fas fa-spinner fa-spin" aria-hidden="true"></i></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% comment %} Slug -> human label map consumed by rerun_modal.js (window.rerunModalityLabels).
+Labels are ProcessingStep names (admin/common/processingstep), falling back to modality
+labels when a domain declares no processing steps. {% endcomment %}
+<script id="rerun-modality-labels" type="application/json">{
+{% for slug, label in rerun_step_labels.items %}"{{ slug }}": "{{ label }}"{% if not forloop.last %},{% endif %}{% endfor %}
+}</script>

--- a/templates/common/patient_detail.html
+++ b/templates/common/patient_detail.html
@@ -67,6 +67,9 @@ worker still parses headers through it (finding F2).
 {% cornerstone_entry 'photo-stack' %}
 {% endif %}
 
+{# Rerun picker for the header's Rerun button (modal markup comes with the header) #}
+<script src="{% static 'js/rerun_modal.js' %}"></script>
+
 {# Main patient detail controller #}
 <script src="{% static 'js/patient_detail.js' %}"></script>
 {% if ns == 'maxillo' %}

--- a/templates/common/patient_list.html
+++ b/templates/common/patient_list.html
@@ -14,6 +14,7 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="{% static 'js/rerun_modal.js' %}"></script>
 <script src="{% static 'js/patient_list.js' %}"></script>
 {% endblock %}
 

--- a/templates/common/sections/patient_header_section.html
+++ b/templates/common/sections/patient_header_section.html
@@ -9,10 +9,10 @@
   on the page via plain querySelector and POSTs to update-name/) — this is now
   that one instance; scan_settings_section.html no longer renders its own.
 
-  Rerun/Delete reuse the same endpoints the patients list uses
-  (`patient/<id>/rerun-processing/`, `patient/<id>/delete/`), called directly
-  here rather than via patient_list.js's modal (that JS/modal pair is list-page
-  only) — kept intentionally simple: confirm(), then POST, then reload/redirect.
+  Rerun opens the same step picker the patients list uses — the modal partial plus
+  static/js/rerun_modal.js, shared by both pages — so a rerun here is a choice of
+  processing steps rather than "all of them". Delete stays a confirm() + POST to
+  `patient/<id>/delete/`.
   Per-patient Export is not built (not selected by the user).
 {% endcomment %}
 <div class="patient-header">
@@ -42,35 +42,29 @@
     </div>
     {% if user_profile.is_admin %}
     <div class="patient-header__actions">
+        {% comment %} No steps means no rerun endpoint worth calling (laparoscopy has none). {% endcomment %}
+        {% if rerunnable_step_slugs %}
         <button type="button" class="btn btn-secondary btn-sm" id="headerRerunBtn">
             <i class="fas fa-rotate" aria-hidden="true"></i>Rerun
         </button>
+        {% endif %}
         <button type="button" class="btn btn-danger btn-sm" id="headerDeleteBtn">
             <i class="fas fa-trash" aria-hidden="true"></i>Delete
         </button>
     </div>
     <script>
     (function () {
-        function csrf() {
-            var m = document.cookie.match(/csrftoken=([^;]+)/);
-            return m ? m[1] : '';
-        }
         var rerunBtn = document.getElementById('headerRerunBtn');
         var deleteBtn = document.getElementById('headerDeleteBtn');
         var patientId = {{ patient.patient_id }};
 
         if (rerunBtn) {
             rerunBtn.addEventListener('click', function () {
-                if (!confirm('Rerun processing for all modalities on this patient?')) return;
-                fetch('/' + window.projectNamespace + '/patient/' + patientId + '/rerun-processing/', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf() },
-                    body: JSON.stringify({ jobs: window.__patientHeaderStepSlugs || [] })
-                }).then(function (r) { return r.json(); }).then(function (data) {
-                    if (data.success) { window.location.reload(); }
-                    else if (window.appNotify) { window.appNotify('error', data.error || 'Failed to rerun jobs'); }
-                }).catch(function () {
-                    if (window.appNotify) window.appNotify('error', 'Network error');
+                window.YggRerunModal.open({
+                    patientId: patientId,
+                    patientName: '{{ patient.name|default:"Unnamed scan"|escapejs }}',
+                    steps: window.__patientHeaderStepSlugs || [],
+                    onSuccess: function () { window.location.reload(); }
                 });
             });
         }
@@ -79,7 +73,7 @@
                 if (!confirm('Delete this patient? This cannot be undone.')) return;
                 fetch('/' + window.projectNamespace + '/patient/' + patientId + '/delete/', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf() },
+                    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': window.yggCsrfToken() },
                     body: JSON.stringify({})
                 }).then(function (r) { return r.json(); }).then(function (data) {
                     if (data.success) { window.location.href = '/' + window.projectNamespace + '/'; }
@@ -93,7 +87,7 @@
     </script>
     {% endif %}
 </div>
-{% comment %} Processing step slugs for the header's "rerun all" action (possible for this
+{% comment %} Processing steps offered by the header's Rerun picker (possible for this
 patient, computed in the patient_detail view; excludes nothing at the root,
 downstream steps included). {% endcomment %}
 <script>
@@ -101,3 +95,6 @@ window.__patientHeaderStepSlugs = [
 {% for s in rerunnable_step_slugs %}"{{ s }}"{% if not forloop.last %},{% endif %}{% endfor %}
 ];
 </script>
+{% if user_profile.is_admin and rerunnable_step_slugs %}
+{% include 'common/partials/rerun_modal.html' %}
+{% endif %}

--- a/templates/common/sections/report_template_section.html
+++ b/templates/common/sections/report_template_section.html
@@ -173,7 +173,7 @@
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-CSRFToken': document.cookie.match(/csrftoken=([^;]+)/)?.[1] ?? '',
+                    'X-CSRFToken': window.yggCsrfToken(),
                 },
                 body: JSON.stringify({ language: lang }),
             }).catch(function () {/* non-critical */});


### PR DESCRIPTION
Three findings from one report: *"job 20724 — bracket-prediction — failed"*.

## 1. `iter_input_keys` handed the cluster three keys for one file

Job 20724 (patient 6937) died 5s into SLURM 102579 with a 404 from `ygg-stage pull`,
having successfully pulled the first of its two IOS meshes.

`iter_input_keys` treated every string leaf of `input_files` as an object-storage key.
Jobs completed before 2026-07-29 stored `output_files` as `{path, filename, content_type}`,
and `Job._pull_dependency_outputs` merges a dependency's `output_files` into its
dependents' `input_files` verbatim — so `YGG_INPUT_KEYS` became six entries, four of
them bare filenames and MIME types:

```
maxillo/.../lower_oriented.stl  lower_oriented.stl  model/stl  maxillo/.../upper_oriented.stl  ...
```

The first real key pulled; `lower_oriented.stl` HeadObject'd 404 and failed the job.

Only `path` is a key. Fixed at `iter_input_keys` — the single boundary that turns
`input_files` into keys — so the 2152 stored descriptor rows stay readable instead of
needing a data migration. The cluster needed no change: `BracketPrediction/run.sbatch`
is the stock template and both objects exist in storage.

## 2. Rerunning anything answered 403

`Forbidden (CSRF token from the 'X-Csrftoken' HTTP header has incorrect length.)`

Settings enable `CSRF_USE_SESSIONS` and `CSRF_COOKIE_HTTPONLY`, so the token is in the
session and the cookie is unreadable from JS — but four call sites scraped
`document.cookie.match(/csrftoken=([^;]+)/)` anyway. Unanchored, so it matched a
substring of some unrelated cookie and Django rejected the length. The patients list
was unaffected only because it read the rendered hidden input.

`base.html` now renders the tag once; `window.yggCsrfToken()` in `ygg-ui.js` is the one
reader. Fixes the header's Rerun **and** Delete, the notifications feed, and the report
language toggle — all silently 403ing.

## 3. The header's Rerun now picks steps

It fired a `confirm()` and reran everything; the patients list has offered a picker
since 3.0. Same endpoint, same DAG-derived slugs — only the picker was missing. The
modal markup, CSS and logic now live in one place and both pages open it, differing
only in what follows: the list flips that row's status pills, the detail page reloads.
The bulk-rerun modal is untouched.

The button renders only when the patient has rerunnable steps, retiring a dead path —
laparoscopy has no rerun endpoint, so its header button POSTed an empty job list to a 404.

## Verification

- Full Django suite: 1319 tests, OK (MySQL)
- `npm test`: 902 pass; `npm run build` leaves the bundle byte-identical; `npm run verify` ok
- New coverage: descriptor + mixed `iter_input_keys` cases; detail page renders the picker
  with `ProcessingStep` labels; button and modal absent without steps; both pages render a
  CSRF token and scrape no cookie

## After merge

Prod bakes the code into its image, so job 20724 only clears after a rebuild + restart:

```
docker compose build web runner-worker && docker compose up -d web runner-worker
docker compose exec web python manage.py shell -c "
from common.models import Job
j = Job.objects.get(pk=20724); j.retry_count = 0; j.status = 'pending'; j.save()"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
